### PR TITLE
added conditions to prompt parts (#46)

### DIFF
--- a/lib/prompt.ps1
+++ b/lib/prompt.ps1
@@ -55,6 +55,20 @@ function global:pshazz_write_prompt($prompt, $vars) {
 	# that evaluate to blank strings
 	$prompt | % {
 		$str = eval $_[2]
+
+		# check if there is additional conditional parameter for prompt part
+		if($_.Count -ge 4) {
+			$cond = eval $_[3]
+			$condition = ([string]::isnullorwhitespace($_[3]) -or $cond)
+		} else {
+			$condition = $true
+		}
+
+		# empty up the prompt part if condition fails
+		if(!$condition) {
+			$str = ""
+		}
+
 		if(![string]::isnullorwhitespace($str)) {
 			$fg = $_[0]; $bg = $_[1]
 			if(!$fg) { $fg = $fg_default }

--- a/plugins/git.ps1
+++ b/plugins/git.ps1
@@ -51,6 +51,8 @@ function global:pshazz:git:prompt {
 		$vars.git_local_state = ""
 		$vars.git_remote_state = ""
 
+		$vars.is_git = $true
+
 		$vars.git_lbracket = $global:pshazz.git.prompt_lbracket
 		$vars.git_rbracket = $global:pshazz.git.prompt_rbracket
 

--- a/themes/aag.json
+++ b/themes/aag.json
@@ -1,0 +1,20 @@
+﻿{
+	"plugins": [ "git", "hg", "ssh", "z", "aliases" ],
+	"prompt": [
+		[ "",   "", "┌—", "" ],
+		[ "darkgreen",   "", " $user@$hostname", "$true" ],
+		[ "darkyellow",  "", " $pwd", "" ],
+		[ "",            "", " `n├— git —→", "$is_git" ],
+		[ "",            "", " $git_lbracket$git_branch", "" ],
+		[ "red",         "", " $git_dirty", "" ],
+		[ "",            "", "$git_rbracket", ""],
+		[ "",            "", " $hg_lbracket$hg_branch$hg_bookmark", "" ],
+		[ "red",         "", "$hg_dirty", "" ],
+		[ "",            "", "$hg_rbracket", "" ],
+		[ "",            "", "`n└———→", "" ]
+	],
+	"git": {
+		"prompt_lbracket": "[",
+		"prompt_rbracket": "]"
+	}
+}


### PR DESCRIPTION
* added conditions to prompt parts

- fourth index in the prompt part array defines the condition; if empty
or $true then only render that part
- added variable to git plugin to see if the current directory is a git
repository; used for the  prompt condition
- new theme added aag.json

* corrected condition evaluation

- added comments
- changed the count check from 3 to 4